### PR TITLE
[bugfix] change ChapterParser.parsehead head selector

### DIFF
--- a/gitbook.py
+++ b/gitbook.py
@@ -103,7 +103,7 @@ class ChapterParser():
             return 'level' + str(num)
         for head in self.heads:
             if context.xpath(head):
-                self.head = context.xpath(head)[0].text
+                self.head = IndexParser.titleparse(context.xpath(head)[0])
                 if self.head in self.index_title:
                     context.xpath(head)[0].text = self.index_title
                 context.xpath(head)[0].attrib['class'] = level(self.baselevel)


### PR DESCRIPTION
Because the original method can't handle nested heads