### PR TITLE
修复lxml.etree.SerialisationError: IO_ENCODER报错

### DIFF
--- a/gitbook2pdf/gitbook2pdf.py
+++ b/gitbook2pdf/gitbook2pdf.py
@@ -102,7 +102,7 @@ class ChapterParser():
         if context.find('footer'):
             context.remove(context.find('footer'))
         context = self.parsehead(context)
-        return html.unescape(ET.tostring(context).decode())
+        return html.unescape(ET.tostring(context,encoding='utf-8').decode())
 
     def parsehead(self, context):
         def level(num):


### PR DESCRIPTION
采集命令：

```
$ python3 gitbook.py https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/
```

报如下错误：

```
/usr/lib/python3/dist-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.5) or chardet (3.0.4) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch1.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch2.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch3.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch4.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch5.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch6.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch7.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch8.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch9.html
crawling :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch10.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch4.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch10.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch5.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch3.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch2.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch6.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch1.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch7.html
done :  https://llh911001.gitbooks.io/mostly-adequate-guide-chinese/content/ch9.html
Traceback (most recent call last):
  File "gitbook.py", line 5, in <module>
    Gitbook2PDF(url).run()
  File "/home/yxz/gitbook2pdf/gitbook2pdf/gitbook2pdf.py", line 198, in run
    loop.run_until_complete(self.crawl_main_content(content_urls))
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/yxz/gitbook2pdf/gitbook2pdf/gitbook2pdf.py", line 220, in crawl_main_content
    await asyncio.gather(*tasks)
  File "/home/yxz/gitbook2pdf/gitbook2pdf/gitbook2pdf.py", line 241, in gettext
    text = ChapterParser(metatext, title, level, ).parser()
  File "/home/yxz/gitbook2pdf/gitbook2pdf/gitbook2pdf.py", line 105, in parser
    return html.unescape(ET.tostring(context).decode())
  File "src/lxml/etree.pyx", line 3437, in lxml.etree.tostring
  File "src/lxml/serializer.pxi", line 139, in lxml.etree._tostring
  File "src/lxml/serializer.pxi", line 199, in lxml.etree._raiseSerialisationError
lxml.etree.SerialisationError: IO_ENCODER
```

根据搜索到的 [方法](https://blog.csdn.net/weixin_39190382/article/details/105111933)  解决了这个报错。